### PR TITLE
19 Sudokus abspeichern und auslesen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,17 +9,42 @@
   <version>1.0-SNAPSHOT</version>
     <dependencies>
         <dependency>
+            <artifactId>junit-jupiter-engine</artifactId>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
+            <scope>test</scope>
+            <version>5.9.0</version>
+        </dependency>
+        <dependency>
+            <artifactId>gson</artifactId>
+            <groupId>com.google.code.gson</groupId>
+            <version>2.10</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+    </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,52 @@
   <groupId>de.dhbw.karlsruhe</groupId>
   <artifactId>cli-sudoku</artifactId>
   <version>1.0-SNAPSHOT</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-  <properties>
+    <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -14,42 +14,6 @@
             <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     </dependencies>
 
     <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
+++ b/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
 
-    static final String SUDOKUFILENAME = "SudokuStoreFile";
+    private static final String SUDOKUFILENAME = "SudokuStoreFile";
 
     @Override
     public void saveSudoku(Sudoku sudoku) {
@@ -48,7 +48,7 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
     }
 
     @Override
-    public List<Sudoku> getAllSudoku() {
+    public List<Sudoku> getAllSudokus() {
         List<Sudoku> sudokuList = new ArrayList<>();
 
         try (BufferedReader br = new BufferedReader(new FileReader(getFullFilePath(SUDOKUFILENAME)))) {

--- a/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
+++ b/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
@@ -1,5 +1,6 @@
 package de.dhbw.karlsruhe.adapter;
 
+import de.dhbw.karlsruhe.model.Difficulty;
 import de.dhbw.karlsruhe.model.Sudoku;
 import de.dhbw.karlsruhe.ports.SudokuPort;
 
@@ -20,6 +21,13 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(getFullFilePath(SUDOKUFILENAME), true))) {
             String id = String.format("ID=%s", sudoku.getId());
             writer.append(id);
+            writer.newLine();
+
+            String diff = "Difficulty=";
+            if (sudoku.getDifficulty() != null) {
+                 diff = String.format("Difficulty=%s", sudoku.getDifficulty().getName());
+            }
+            writer.append(diff);
             writer.newLine();
 
             StringBuilder tmpGameField = new StringBuilder();
@@ -49,17 +57,24 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
             while (line != null) {
                 if (!line.contains("ID=")) {
                     line = br.readLine();
+                    line = br.readLine();
                     continue;
                 }
-
                 String[] idArray = line.split("=");
                 String tmpId = idArray[1];
+                line = br.readLine();
+                String[] diffArray = line.split("=");
+                String tmpDiff= "";
+                if (diffArray.length > 1) {
+                    tmpDiff = diffArray[1];
+                }
+                String finalTmpDiff = tmpDiff;
+                Difficulty selectedDiff = Difficulty.stream()
+                        .filter(d -> d.match(finalTmpDiff))
+                        .findFirst()
+                        .orElse(null);
 
-
-
-                sudokuList.add(new Sudoku(tmpId, readGameField(br)));
-
-
+                sudokuList.add(new Sudoku(tmpId, readGameField(br), selectedDiff));
                 line = br.readLine();
             }
         } catch (IOException e) {
@@ -77,16 +92,26 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
             while (line != null) {
                 if (!line.contains("ID=")) {
                     line = br.readLine();
+                    line = br.readLine();
                     continue;
                 }
-
                 String[] idArray = line.split("=");
                 String tmpId = idArray[1];
-
+                line = br.readLine();
                 if (id.equals(tmpId)){
-                    return new Sudoku(tmpId, readGameField(br));
-                }
+                    String[] diffArray = line.split("=");
+                    String tmpDiff= "";
+                    if (diffArray.length > 1) {
+                        tmpDiff = diffArray[1];
+                    }
+                    String finalTmpDiff = tmpDiff;
+                    Difficulty selectedDiff = Difficulty.stream()
+                            .filter(d -> d.match(finalTmpDiff))
+                            .findFirst()
+                            .orElse(null);
+                    return new Sudoku(tmpId, readGameField(br), selectedDiff);
 
+                }
                 line = br.readLine();
             }
             System.out.println("Sudoku not found!");
@@ -110,6 +135,7 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
                     pw.flush();
                     line = br.readLine();
                 }else {
+                    line = br.readLine();
                     line = br.readLine();
                     line = br.readLine();
                 }

--- a/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
+++ b/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
@@ -1,0 +1,115 @@
+package de.dhbw.karlsruhe.adapter;
+
+import de.dhbw.karlsruhe.model.Sudoku;
+import de.dhbw.karlsruhe.ports.SudokuPort;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
+
+    final String sudokuFileName = "SudokuStoreFile";
+
+    @Override
+    public void saveSudoku(Sudoku sudoku) {
+        prepareFileStructure(sudokuFileName);
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(getFullFilePath(sudokuFileName), true))) {
+            String id = String.format("ID=%s", sudoku.getId());
+            writer.append(id);
+            writer.newLine();
+
+            StringBuilder tmpGameField = new StringBuilder();
+            tmpGameField.append("GameField=");
+            for (int i = 0; i<9; i++){
+                for (int j = 0; j<9; j++){
+                    tmpGameField.append(sudoku.getGameField()[i][j]);
+                    tmpGameField.append(",");
+                }
+            }
+            tmpGameField.deleteCharAt(tmpGameField.length()-1);
+            writer.append(tmpGameField.toString());
+            writer.newLine();
+        } catch (IOException e) {
+            System.err.println(e.getMessage());
+        }
+
+    }
+
+    @Override
+    public List<Sudoku> getAllSudoku() {
+        List<Sudoku> sudokuList = new ArrayList<>();
+
+        try (BufferedReader br = new BufferedReader(new FileReader(getFullFilePath(sudokuFileName)))) {
+            String line = br.readLine();
+
+            while (line != null) {
+                if (!line.contains("ID=")) {
+                    line = br.readLine();
+                    continue;
+                }
+
+                String[] idArray = line.split("=");
+                String tmpId = idArray[1];
+
+
+
+                sudokuList.add(new Sudoku(tmpId, readGameField(br)));
+
+
+                line = br.readLine();
+            }
+        } catch (IOException e) {
+            return Collections.emptyList();
+        }
+        return sudokuList;
+    }
+
+    @Override
+    public Sudoku getSudoku(String id) {
+
+        try (BufferedReader br = new BufferedReader(new FileReader(getFullFilePath(sudokuFileName)))) {
+            String line = br.readLine();
+
+            while (line != null) {
+                if (!line.contains("ID=")) {
+                    line = br.readLine();
+                    continue;
+                }
+
+                String[] idArray = line.split("=");
+                String tmpId = idArray[1];
+
+                if (id.equals(tmpId)){
+                    return new Sudoku(tmpId, readGameField(br));
+                }
+
+            }
+            System.out.println("Sudoku not found!");
+        } catch (IOException e) {
+            return null;
+        }
+        return null;
+    }
+
+    private String[][] readGameField(BufferedReader br) throws IOException {
+        String line = br.readLine();
+
+        String[] array = line.split("=");
+        String[] fieldArray = array[1].split(",");
+
+        String[][] tmpGameField = new String[9][9];
+
+        int fieldCount = 0;
+        for (int i = 0; i<9; i++){
+            for (int j = 0; j<9; j++){
+                tmpGameField[i][j] = fieldArray[fieldCount];
+                fieldCount++;
+            }
+        }
+
+        return tmpGameField;
+    }
+}

--- a/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
+++ b/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
@@ -86,6 +86,7 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
                     return new Sudoku(tmpId, readGameField(br));
                 }
 
+                line = br.readLine();
             }
             System.out.println("Sudoku not found!");
         } catch (IOException e) {

--- a/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
+++ b/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
@@ -92,7 +92,6 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
             while (line != null) {
                 if (!line.contains("ID=")) {
                     line = br.readLine();
-                    line = br.readLine();
                     continue;
                 }
                 String[] idArray = line.split("=");

--- a/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
+++ b/src/main/java/de/dhbw/karlsruhe/adapter/SudokuAdapter.java
@@ -57,30 +57,32 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
             while (line != null) {
                 if (!line.contains("ID=")) {
                     line = br.readLine();
-                    line = br.readLine();
                     continue;
                 }
                 String[] idArray = line.split("=");
                 String tmpId = idArray[1];
                 line = br.readLine();
-                String[] diffArray = line.split("=");
-                String tmpDiff= "";
-                if (diffArray.length > 1) {
-                    tmpDiff = diffArray[1];
-                }
-                String finalTmpDiff = tmpDiff;
-                Difficulty selectedDiff = Difficulty.stream()
-                        .filter(d -> d.match(finalTmpDiff))
-                        .findFirst()
-                        .orElse(null);
 
-                sudokuList.add(new Sudoku(tmpId, readGameField(br), selectedDiff));
+                sudokuList.add(new Sudoku(tmpId, readGameField(br), extractDifficulty(line)));
                 line = br.readLine();
             }
         } catch (IOException e) {
             return Collections.emptyList();
         }
         return sudokuList;
+    }
+
+    private Difficulty extractDifficulty(String line) {
+        String[] diffArray = line.split("=");
+        String tmpDiff= "";
+        if (diffArray.length > 1) {
+            tmpDiff = diffArray[1];
+        }
+        String finalTmpDiff = tmpDiff;
+        return Difficulty.stream()
+                .filter(d -> d.match(finalTmpDiff))
+                .findFirst()
+                .orElse(null);
     }
 
     @Override
@@ -98,18 +100,7 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
                 String tmpId = idArray[1];
                 line = br.readLine();
                 if (id.equals(tmpId)){
-                    String[] diffArray = line.split("=");
-                    String tmpDiff= "";
-                    if (diffArray.length > 1) {
-                        tmpDiff = diffArray[1];
-                    }
-                    String finalTmpDiff = tmpDiff;
-                    Difficulty selectedDiff = Difficulty.stream()
-                            .filter(d -> d.match(finalTmpDiff))
-                            .findFirst()
-                            .orElse(null);
-                    return new Sudoku(tmpId, readGameField(br), selectedDiff);
-
+                    return new Sudoku(tmpId, readGameField(br), extractDifficulty(line));
                 }
                 line = br.readLine();
             }
@@ -132,13 +123,11 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
                 if (!line.trim().equals("ID=" + id)) {
                     pw.println(line);
                     pw.flush();
-                    line = br.readLine();
                 }else {
                     line = br.readLine();
                     line = br.readLine();
-                    line = br.readLine();
                 }
-
+                line = br.readLine();
             }
         } catch (IOException e) {
             System.out.println("Error occurred while deleting sudoku.");
@@ -149,7 +138,6 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
         }catch(IOException e){
             System.out.println("Could not delete file.");
         }
-
 
         //Rename the new file to the filename the original file had.
         if (!tmpFile.renameTo(inFile))
@@ -162,7 +150,6 @@ public class SudokuAdapter extends AbstractStoreAdapter implements SudokuPort {
 
         String[] array = line.split("=");
         String[] fieldArray = array[1].split(",");
-
         String[][] tmpGameField = new String[9][9];
 
         int fieldCount = 0;

--- a/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
+++ b/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
@@ -8,15 +8,22 @@ public class Sudoku {
 
   private String id;
   private String[][] gameField;
+  private Difficulty difficulty;
 
   public Sudoku() {
     id = UUID.randomUUID().toString();
     gameField = new String[9][9];
+    difficulty = null;
   }
 
-  public Sudoku(String id, String[][] gameField) {
+  public Difficulty getDifficulty() {
+    return difficulty;
+  }
+
+  public Sudoku(String id, String[][] gameField, Difficulty difficulty) {
     this.id = id;
     this.gameField = gameField;
+    this.difficulty = difficulty;
   }
 
   public String getId() {
@@ -27,17 +34,18 @@ public class Sudoku {
     return gameField;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     Sudoku sudoku = (Sudoku) o;
-    return id.equals(sudoku.id) && Arrays.deepEquals(gameField, sudoku.gameField);
+    return id.equals(sudoku.id) && Arrays.deepEquals(gameField, sudoku.gameField) && difficulty == sudoku.difficulty;
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(id);
+    int result = Objects.hash(id, difficulty);
     result = 31 * result + Arrays.hashCode(gameField);
     return result;
   }

--- a/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
+++ b/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
@@ -12,6 +12,11 @@ public class Sudoku {
     gameField = new String[9][9];
   }
 
+  public Sudoku(String id, String[][] gameField) {
+    id = UUID.randomUUID().toString();
+    gameField = new String[9][9];
+  }
+
   public String getId() {
     return id;
   }

--- a/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
+++ b/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
@@ -1,5 +1,7 @@
 package de.dhbw.karlsruhe.model;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.UUID;
 
 public class Sudoku {
@@ -13,8 +15,8 @@ public class Sudoku {
   }
 
   public Sudoku(String id, String[][] gameField) {
-    id = UUID.randomUUID().toString();
-    gameField = new String[9][9];
+    this.id = id;
+    this.gameField = gameField;
   }
 
   public String getId() {
@@ -23,6 +25,21 @@ public class Sudoku {
 
   public String[][] getGameField() {
     return gameField;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Sudoku sudoku = (Sudoku) o;
+    return id.equals(sudoku.id) && Arrays.deepEquals(gameField, sudoku.gameField);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(id);
+    result = 31 * result + Arrays.hashCode(gameField);
+    return result;
   }
 
   public void print() {

--- a/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
+++ b/src/main/java/de/dhbw/karlsruhe/model/Sudoku.java
@@ -13,17 +13,17 @@ public class Sudoku {
   public Sudoku() {
     id = UUID.randomUUID().toString();
     gameField = new String[9][9];
-    difficulty = null;
-  }
-
-  public Difficulty getDifficulty() {
-    return difficulty;
+    difficulty = Difficulty.EASY;
   }
 
   public Sudoku(String id, String[][] gameField, Difficulty difficulty) {
     this.id = id;
     this.gameField = gameField;
     this.difficulty = difficulty;
+  }
+
+  public Difficulty getDifficulty() {
+    return difficulty;
   }
 
   public String getId() {

--- a/src/main/java/de/dhbw/karlsruhe/ports/SudokuPort.java
+++ b/src/main/java/de/dhbw/karlsruhe/ports/SudokuPort.java
@@ -8,7 +8,7 @@ public interface SudokuPort {
 
     void saveSudoku(Sudoku sudoku);
 
-    List<Sudoku> getAllSudoku();
+    List<Sudoku> getAllSudokus();
 
     Sudoku getSudoku(String id);
 

--- a/src/main/java/de/dhbw/karlsruhe/ports/SudokuPort.java
+++ b/src/main/java/de/dhbw/karlsruhe/ports/SudokuPort.java
@@ -1,0 +1,14 @@
+package de.dhbw.karlsruhe.ports;
+
+import de.dhbw.karlsruhe.model.Sudoku;
+
+import java.util.List;
+
+public interface SudokuPort {
+
+    void saveSudoku(Sudoku sudoku);
+
+    List<Sudoku> getAllSudoku();
+
+    Sudoku getSudoku(String id);
+}

--- a/src/main/java/de/dhbw/karlsruhe/ports/SudokuPort.java
+++ b/src/main/java/de/dhbw/karlsruhe/ports/SudokuPort.java
@@ -11,4 +11,6 @@ public interface SudokuPort {
     List<Sudoku> getAllSudoku();
 
     Sudoku getSudoku(String id);
+
+    void deleteSudoku(String id);
 }

--- a/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
@@ -2,18 +2,19 @@ package de.dhbw.karlsruhe.adapter;
 
 import de.dhbw.karlsruhe.model.Sudoku;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.UUID;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 
 class SudokuAdapterTest {
 
     @Test
     void saveSudokuTest(){
-        String id = UUID.randomUUID().toString();
+        // Same Id for deleting Test
+        String id = "123";
         String[][] gameField = new String[9][9];
 
         for (int i = 0; i<9; i++){
@@ -22,6 +23,7 @@ class SudokuAdapterTest {
             }
         }
 
+        // valid Sudoku from sudoku.com
         gameField[0][5] = "5";
         gameField[0][6] = "9";
         gameField[0][7] = "2";
@@ -78,6 +80,38 @@ class SudokuAdapterTest {
         Sudoku readSudoku = sudokuAdapter.getSudoku(id);
 
         assertEquals(sudoku, readSudoku);
+
+    }
+
+    @Test
+    void deleteSudokuTest(){
+        SudokuAdapter sudokuAdapter = new SudokuAdapter();
+        sudokuAdapter.deleteSudoku("123");
+
+        try (BufferedReader br = new BufferedReader(new FileReader(sudokuAdapter.getFullFilePath(SudokuAdapter.SUDOKUFILENAME)))) {
+            String line = br.readLine();
+
+            while (line != null) {
+                if (!line.contains("ID=")) {
+                    line = br.readLine();
+                    continue;
+                }
+
+                String[] idArray = line.split("=");
+                String tmpId = idArray[1];
+
+                if (tmpId.equals("123")){
+                    fail();
+                }
+
+                line = br.readLine();
+            }
+            assertTrue(true);
+        } catch (IOException e) {
+            System.out.println("Error occurred while reading file.");
+        }
+
+
 
     }
 }

--- a/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
@@ -1,5 +1,6 @@
 package de.dhbw.karlsruhe.adapter;
 
+import de.dhbw.karlsruhe.model.Difficulty;
 import de.dhbw.karlsruhe.model.Sudoku;
 import org.junit.jupiter.api.Test;
 
@@ -71,7 +72,7 @@ class SudokuAdapterTest {
         gameField[8][7] = "1";
         gameField[8][8] = "6";
 
-        Sudoku sudoku = new Sudoku(id, gameField);
+        Sudoku sudoku = new Sudoku(id, gameField, null);
 
         SudokuAdapter sudokuAdapter = new SudokuAdapter();
 
@@ -111,7 +112,6 @@ class SudokuAdapterTest {
             System.out.println("Error occurred while reading file.");
         }
 
-
-
     }
+
 }

--- a/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
@@ -72,7 +72,7 @@ class SudokuAdapterTest {
         gameField[8][7] = "1";
         gameField[8][8] = "6";
 
-        Sudoku sudoku = new Sudoku(id, gameField, null);
+        Sudoku sudoku = new Sudoku(id, gameField, Difficulty.EASY);
 
         SudokuAdapter sudokuAdapter = new SudokuAdapter();
 

--- a/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
@@ -2,6 +2,7 @@ package de.dhbw.karlsruhe.adapter;
 
 import de.dhbw.karlsruhe.model.Difficulty;
 import de.dhbw.karlsruhe.model.Sudoku;
+import de.dhbw.karlsruhe.ports.SudokuPort;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -74,11 +75,11 @@ class SudokuAdapterTest {
 
         Sudoku sudoku = new Sudoku(id, gameField, Difficulty.EASY);
 
-        SudokuAdapter sudokuAdapter = new SudokuAdapter();
+        SudokuPort sudokuPort = new SudokuAdapter();
 
-        sudokuAdapter.saveSudoku(sudoku);
+        sudokuPort.saveSudoku(sudoku);
 
-        Sudoku readSudoku = sudokuAdapter.getSudoku(id);
+        Sudoku readSudoku = sudokuPort.getSudoku(id);
 
         assertEquals(sudoku, readSudoku);
 
@@ -86,10 +87,10 @@ class SudokuAdapterTest {
 
     @Test
     void deleteSudokuTest(){
-        SudokuAdapter sudokuAdapter = new SudokuAdapter();
-        sudokuAdapter.deleteSudoku("123");
+        SudokuPort sudokuPort = new SudokuAdapter();
+        sudokuPort.deleteSudoku("123");
 
-        try (BufferedReader br = new BufferedReader(new FileReader(sudokuAdapter.getFullFilePath(SudokuAdapter.SUDOKUFILENAME)))) {
+        try (BufferedReader br = new BufferedReader(new FileReader("src/main/resources/fileStore/SudokuStoreFile"))) {
             String line = br.readLine();
 
             while (line != null) {

--- a/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
+++ b/src/test/java/de/dhbw/karlsruhe/adapter/SudokuAdapterTest.java
@@ -1,0 +1,83 @@
+package de.dhbw.karlsruhe.adapter;
+
+import de.dhbw.karlsruhe.model.Sudoku;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+class SudokuAdapterTest {
+
+    @Test
+    void saveSudokuTest(){
+        String id = UUID.randomUUID().toString();
+        String[][] gameField = new String[9][9];
+
+        for (int i = 0; i<9; i++){
+            for (int j = 0; j<9; j++){
+                gameField[i][j] = "";
+            }
+        }
+
+        gameField[0][5] = "5";
+        gameField[0][6] = "9";
+        gameField[0][7] = "2";
+
+        gameField[1][3] = "9";
+        gameField[1][5] = "2";
+        gameField[1][6] = "8";
+        gameField[1][8] = "3";
+
+        gameField[2][4] = "7";
+        gameField[2][5] = "4";
+
+        gameField[3][1] = "9";
+        gameField[3][2] = "6";
+        gameField[3][3] = "2";
+        gameField[3][4] = "1";
+        gameField[3][6] = "5";
+        gameField[3][8] = "7";
+
+        gameField[4][1] = "5";
+        gameField[4][2] = "7";
+        gameField[4][5] = "6";
+
+        gameField[5][0] = "2";
+        gameField[5][1] = "8";
+        gameField[5][2] = "4";
+        gameField[5][4] = "5";
+        gameField[5][6] = "6";
+        gameField[5][7] = "9";
+
+        gameField[6][0] = "6";
+        gameField[6][1] = "7";
+        gameField[6][6] = "4";
+        gameField[6][8] = "9";
+
+        gameField[7][0] = "8";
+        gameField[7][1] = "3";
+        gameField[7][6] = "7";
+        gameField[7][7] = "5";
+        gameField[7][8] = "2";
+
+        gameField[8][1] = "4";
+        gameField[8][4] = "2";
+        gameField[8][6] = "3";
+        gameField[8][7] = "1";
+        gameField[8][8] = "6";
+
+        Sudoku sudoku = new Sudoku(id, gameField);
+
+        SudokuAdapter sudokuAdapter = new SudokuAdapter();
+
+        sudokuAdapter.saveSudoku(sudoku);
+
+        Sudoku readSudoku = sudokuAdapter.getSudoku(id);
+
+        assertEquals(sudoku, readSudoku);
+
+    }
+}


### PR DESCRIPTION
Difficulty zu Sudoku hinzugefügt.
Equals und hashCode Methode zu Sudoku hinzugefügt.
Testordner und erste Tests angelegt.
SudokuAdapter Klasse erstellt. Methoden zum Speichern, auslesen und löschen von Sudokus.
Werte werden in der Reihenfolge: Id, Difficulty, GameField in die Speicherdatei geschrieben.

Tests:
1. Speichern eines Sudokus
2. Löschen eins Sudokus anhand seiner Id

Closes #19